### PR TITLE
Fix multi payments

### DIFF
--- a/app/Http/Controllers/PaymentSearchController.php
+++ b/app/Http/Controllers/PaymentSearchController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\MembershipPrice;
 use App\Models\Application;
+use App\Models\Payment;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
@@ -49,6 +50,7 @@ class PaymentSearchController extends Controller
         'childfirstname' => 'required'
       ]);
 
+
       $application = Application::where('parentemail', trim(Str::lower($request->input('parentemail'))))
         ->where('childlastname', trim(Str::upper($request->input('childlastname'))))
         ->where('childfirstname', ucwords(trim(Str::lower($request->input('childfirstname')))))
@@ -57,6 +59,8 @@ class PaymentSearchController extends Controller
         ->first();
 
       if ($application != null) {
+        $payment = Payment::where('application_id', $application->id)->get()->first();
+
         $membershipPrice = MembershipPrice::where('is_boarder', $application->is_boarder)
           ->where('schoolyear_id', $application->schoolyear_id)
           ->get()
@@ -66,9 +70,11 @@ class PaymentSearchController extends Controller
           if ($application->rallye->isPetitRallye) {
             return Redirect::back()->withError('E200: ' . 'No membership payment for children in a Petit Rallye.');
           } else {
+
             $data = [
               'application' => $application,
-              'membershipPrice' => $membershipPrice
+              'membershipPrice' => $membershipPrice,
+              'payment' => $payment
             ];
 
             return view('payment.paymentSearchResults')->with($data);

--- a/public/assets/js/pages/payment/submit.js
+++ b/public/assets/js/pages/payment/submit.js
@@ -1,0 +1,7 @@
+(function() {
+    $('.form-prevent-multiple-submits').on('submit',
+        function() {
+            console.log('submit');
+            $('.button-prevent-multiple-submits').attr('disabled', 'true');
+        })
+})();

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -71,6 +71,6 @@
     </div>
 </div>
 </div>
-<h5 class="text-danger" align="center"><i>Notice: All parents including previous members need to apply as a new member by filling a new application</i></p>
+<h5 class="text-danger" align="center"><i>Notice: All parents including previous members need to apply as a new member by filling a new application</i></h5>
 </div>
 @endsection

--- a/resources/views/payment/payment.blade.php
+++ b/resources/views/payment/payment.blade.php
@@ -13,11 +13,13 @@
 
 @section('content')
 <div class='container'>
-  <h2>Subscription Payment Form</h2>
+  <h2>Subscription Payment Form </h2>
+    <h7 class="text-warning" align="center"><i><b>Notice:</b> Be careful not double click on payment button, <br>Also, the process can take several seconds please wait and don't stop-reload the page otherwise you will be charged twice.</i></h7>
+    <p><br></p>
     <div class="row">
       <div class="col-md-10 order-md-1">
         {{-- <form id="payment-form" role="form" action="{{ route('stripe.get') }}" method="GET" class="require-validation" data-secret=""> --}}
-        <form action="{{ route('stripe.charge') }}" method="post" id="payment-form" class="require-validation" data-secret="">
+        <form action="{{ route('stripe.charge') }}" method="post" id="payment-form" class="require-validation form-prevent-multiple-submits" data-secret="">
 
           @csrf
           <input name="application_id" type="hidden" value="{{$application->id}}">
@@ -55,12 +57,42 @@
           </div>
           <hr class="mb-4">
           <div class="col-12">
-            <button id="card-button" class="btn btn-primary btn-lg btn-block" type="submit"><b>Pay Now (£ {{$membershipPrice->mount}})</b></button>
+            <button type="button" id="payment-button" class="btn btn-primary btn-lg btn-block button-prevent-multiple-submits" data-toggle="modal" data-target="#PaymentConfirmationModal_{{$application->id}}">Pay Now (£ {{$membershipPrice->mount}})</button>
           </div>
 
           <hr class="mb-4">
           <div class="mb-3" id="card-message"></div>
-      </form>
+            <!-- +AJO : Modal EDIT section begin -->
+            <div class="modal fade" id="PaymentConfirmationModal_{{$application->id}}" tabindex="-1" role="dialog">
+              <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h4 class="title text-center" id="defaultModalLabel">Confirmation</h4>
+                  </div>
+
+                  <div class="modal-body">
+                    {{ Form::open(['method' => 'POST', 'url' => route('stripe.charge'),'id' => 'payment-form', 'class' => ['require-validation', 'form-prevent-multiple-submits' ]]) }}
+                      @csrf
+
+                    <p for=""><b>Child first name: </b>{{$application->childfirstname}}</p>
+                    <p for=""><b>Child Last name: </b>{{$application->childlastname}}</p>
+                    <p for=""><b>Parent email: </b>{{$application->parentemail}}</p>
+                    <p for=""><b>Membership Price: </b><span class="text-danger">£ {{$membershipPrice->mount}}</span></p>
+
+                    <input name="invitation_id" type="hidden"
+                        value="{{$application->id}}">
+                    <div class="modal-footer">
+                        {{form::submit("Pay Now", ['class' => 'btn btn-primary button-prevent-multiple-submits'])}}
+                        <button type="button" class="btn btn-default float-right"
+                            data-dismiss="modal">Cancel</button>
+                    </div>
+                    {{ Form::close() }}
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- END MODAL EDIT -->
+        </form>
     </div>
   </div>
 </div>
@@ -68,11 +100,21 @@
 @stop
 
 @section('page-script')
-
+  <script src="{{secure_asset('assets/js/pages/payment/submit.js')}}"></script>
   <script src="https://js.stripe.com/v3/"></script>
 
   <script>
   var publishable_key = '{{ env('STRIPE_KEY') }}';
   </script>
   <script src="{{secure_asset('assets/js/pages/payment/card.js') }}"></script>
+
+  <script type="text/javascript">
+  $(document).ready(function() {
+      window.history.pushState(null, "", window.location.href);
+      window.onpopstate = function() {
+          window.history.pushState(null, "", window.location.href);
+          window.onbeforeunload = function() { return "You work will be lost."; };
+      };
+  });
+</script>
 @endsection

--- a/resources/views/payment/paymentSearchResults.blade.php
+++ b/resources/views/payment/paymentSearchResults.blade.php
@@ -59,34 +59,53 @@
                                     <!--<td><strong>Rejected</strong></td>-->
                                     @break
                                     @endswitch
-                                    @switch($application->status)
-                                    @case(0)
-                                    <td><span class="badge badge-info">Application</span></td>
-                                    @break
-                                    @case(4)
-                                    <td><span class="badge badge-danger">TO DO</span></td>
-                                    @break
-                                    @case(2)
-                                    <td><strong>Desactived</strong></td>
-                                    @break
-                                    @case(3)
-                                    <td><span class="badge badge-warning">Waiting list</span></td>
-                                    @break
-                                    @case(1)
-                                    <td><span class="badge badge-success">DONE</span></td>
-                                    @break
-                                    @case(5)
-                                    <!--<td><strong>Ready</strong></td>-->
-                                    @break
-                                    @case(9)
-                                    <td><span class="badge badge-danger">Blocked</span></td>
-                                    <!--<td><strong>Rejected</strong></td>-->
-                                    @break
-                                    @endswitch
+                                    @if ($payment != null && $payment->payment_status == "succeeded" )
+                                      <td><span class="badge badge-success">DONE</span></td>
+                                      @php
+                                        $disabled = "disabled";
+                                        $btnStyle = "";
+                                        $link = "#";
+                                        $icon = "";
+                                        $action = "NONE";
+                                      @endphp
+                                    @else
+                                      @php
+                                        $disabled = "" ;
+                                        $btnStyle ="btn-warning";
+                                        $link="/payments/$application->id/edit";
+                                        $icon = "glyphicon-edit";
+                                        $action = "PAY";
+                                      @endphp
+                                      @switch($application->status)
+                                      @case(0)
+                                      <td><span class="badge badge-info">Application</span></td>
+                                      @break
+                                      @case(4)
+                                      <td><span class="badge badge-danger">TO DO</span></td>
+                                      @break
+                                      @case(2)
+                                      <td><strong>Desactived</strong></td>
+                                      @break
+                                      @case(3)
+                                      <td><span class="badge badge-warning">Waiting list</span></td>
+                                      @break
+                                      @case(1)
+                                      <td><span class="badge badge-success">DONE</span></td>
+                                      @break
+                                      @case(5)
+                                      <!--<td><strong>Ready</strong></td>-->
+                                      @break
+                                      @case(9)
+                                      <td><span class="badge badge-danger">Blocked</span></td>
+                                      <!--<td><strong>Rejected</strong></td>-->
+                                      @break
+                                      @endswitch
+                                    @endif
+
                                     <td><strong>{{$membershipPrice->mount}} (£)</strong></td>
                                     <td>
                                         {{-- <a href="/stripes/{{$application->id}}/edit"><button type="button" class="btn btn-warning btn-sm"><span class="glyphicon glyphicon-edit"></span> PAY</button></a> --}}
-                                        <a href="/payments/{{$application->id}}/edit"><button type="button" class="btn btn-warning btn-sm"><span class="glyphicon glyphicon-edit"></span> PAY</button></a>
+                                        <a class="{{$disabled}}" href="{{ $link }}"><button type="button" class="btn {{$btnStyle}} btn-sm {{$disabled}}"><span class="glyphicon {{$icon}}"></span> {{$action}}</button></a>
                                     </td>
                                 </tr>
                           </tbody>


### PR DESCRIPTION
1 - J’a ajouté une petit message d’information (je vous laisse me corriger et me dire si vous souhaitez une formulation différente)
2 - Avant de présenter le formulaire de paiement je vérifie que je n’ai pas un paiement ‘succeeded’ dans ma base de donnée. si c’est déjà payé on ne peut plus accéder au formulaire (bouton grisé)
3 - A différents moments, avant de valider définitivement le paiement je vérifie également s’il n’est pas déjà effectué et validé dans ma base de données (je n’interroge pas Stripe) .
4- Ensuite j’ai fais en sorte qu’on ne puisse plus cliquer plusieurs fois sur le bouton de paiement. (Du moins on peut cliquer mais c’est sans effet)
5- Une fois le paiement effectué, si on revient en arrière cela ne présente plus le formulaire mais l’info que le paiement est validé.
6- J’ai empêché également le retour arrière pendant le paiement et si on reload la page cela indique paiement déjà effectué
7- Si besoin, J’ai préparé une petite popup pour demander confirmation avant le paiement

![Capture d’écran 2022-09-30 à 15 56 25](https://user-images.githubusercontent.com/17742618/193294433-4867f9ec-041d-49f4-a491-83ea961a0b17.png)
![Capture d’écran 2022-09-30 à 15 57 17](https://user-images.githubusercontent.com/17742618/193294440-08e303d2-dbf9-46a8-823c-d909567da463.png)
![Capture d’écran 2022-09-30 à 16 02 23](https://user-images.githubusercontent.com/17742618/193294444-5b09e545-20d5-45ce-a942-bf14629a0d7b.png)
![Capture d’écran 2022-09-30 à 16 07 33](https://user-images.githubusercontent.com/17742618/193294445-a46c97ce-d43e-4f3d-8982-8faca7a6ab8e.png)

