### PR TITLE
show checkin list on one page

### DIFF
--- a/resources/views/checkinEvent/index.blade.php
+++ b/resources/views/checkinEvent/index.blade.php
@@ -240,6 +240,22 @@
         $(".menu > ul").toggleClass('show-on-mobile');
         e.preventDefault();
       });
+
+      $('.table').DataTable({
+        //retrieve: true,
+        destroy: true,
+        ordering: true,
+        filtering: true,
+        searching: true,
+        "displayStart": 150,
+        "lengthMenu": [ 150, 200],
+        dom: 'Bfrtip',
+        buttons: [
+        'copy',
+        'csv',
+        'print'
+        ]
+      });
       //when clicked on mobile-menu, normal menu is shown as a list, classic rwd menu story (thanks mwl from stackoverflow)
     });
 </script>


### PR DESCRIPTION

Ajout configuration de la table pour afficher la checkin list sur une seule page. 
On peut facilement configurer le nombre d'entrée par page grace aux paramètres

 ```
      "displayStart": 150,
        "lengthMenu": [ 150, 200],
```



```
      $('.table').DataTable({
        //retrieve: true,
        destroy: true,
        ordering: true,
        filtering: true,
        searching: true,
        "displayStart": 150,
        "lengthMenu": [ 150, 200],
        dom: 'Bfrtip',
        buttons: [
        'copy',
        'csv',
        'print'
        ]
      });
```